### PR TITLE
Don't bind call to deckard orientation an extra time

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "requirejs": "~2.1.14",
     "bouncefix.js": "~0.3.0",
     "shade": "~1.1.1",
-    "lockup": "~1.1.1",
+    "lockup": "mobify/lockup#update-deckard",
     "deckard": "~1.1.0",
     "selector-utils": "https://github.com/mobify/selector-utils.git"
   }

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "bouncefix.js": "~0.3.0",
     "shade": "~1.1.1",
     "lockup": "~1.1.1",
-    "deckard": "~1.0.0",
+    "deckard": "~1.1.0",
     "selector-utils": "https://github.com/mobify/selector-utils.git"
   }
 }

--- a/examples/assets/js/main.js
+++ b/examples/assets/js/main.js
@@ -66,9 +66,5 @@ require(['config'], function() {
 
         // Enable active states
         $(document).on('touchstart', function() {});
-
-        $(window).on('resize', function() {
-            $.__deckard.orientation.call($);
-        });
     });
 });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-jshint": "0.10.0",
     "grunt-contrib-sass": "0.8.1",
-    "grunt-contrib-uglify": "~0.8.0",
+    "grunt-contrib-uglify": "~0.9.1",
     "grunt-contrib-watch": "~0.5.1",
     "grunt-css": "~0.5.4",
     "grunt-jscs": "0.7.1",


### PR DESCRIPTION
Status: **Ready for merge**
Reviewers: **@kpeatt**

## Changes
- Removes extra call to Deckard's orientation change call

## Notes
- Just updates the example so this shouldn't require a release.

- [ ] Update lockup version in bower.json prior to merging 