### PR TITLE
Page no longer jump to the top after closing pinny

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bouncefix.js": "0.3.0",
     "deckard": "git+https://github.com/mobify/deckard.git#1.2.0",
     "jquery": "2.2.2",
-    "lockup": "git+https://github.com/mobify/lockup.git#1.1.3",
+    "lockup": "git+https://github.com/mobify/lockup.git#chrome-61-scrollTop",
     "plugin": "git+https://github.com/mobify/plugin.git#3.1.0",
     "requirejs": "2.2.0",
     "requirejs-glob": "git+https://github.com/mobify/requirejs-glob.git",


### PR DESCRIPTION
For latest Chrome 61 on Android.
Linked PRs: https://github.com/mobify/lockup/pull/14

## Changes
- used the updated lockup plugin that fixes the `scrollTop` position

## TODOS:
- [ ] Changes tested and working in supported browsers (see [README](https://github.com/mobify/pinny#browser-compatibility) for supported browsers)
- [ ] Tests added
- [ ] Tests passed
- [ ] Build generated
- [ ] README.md updated
- [ ] CHANGELOG.md updated